### PR TITLE
Cleanup: Change latex to markdown.

### DIFF
--- a/1. The Applications Layer/BB84.md
+++ b/1. The Applications Layer/BB84.md
@@ -9,30 +9,30 @@ This document specifies a definition and pseudo-code for the quantum key distrib
 The BB84 protocol enables two distant parties, (historically known as Alice and Bob), to share a secret key. Quantum mechanics ensures that this key cannot be read by an eavesdropper (also, historically known as Eve) without causing a traceable disturbance to the communications.
 
 ## Protocol Definition
-1- Alice chooses two uniformly random bit strings $a = a_0 a_1 a_2 \ldots$ and $b = b_0 b_1 b_2 \ldots$. The string $a$ contains the bits of the secret key to be sent to Bob; the string $b$ is a basis string (see step 2). At the same time, Bob chooses a unifromly random bit string $c$.
+1- Alice chooses two uniformly random bit strings **_a = a<sub>0</sub>a<sub>1</sub>a<sub>2</sub>..._** and **_b = b<sub>0</sub>b<sub>1</sub>b<sub>2</sub>..._**. The string **_a_** contains the bits of the secret key to be sent to Bob; the string **_b_** is a basis string (see step 2). At the same time, Bob chooses a unifromly random bit string **_c_**.
 
     The bits from the string a are going to be sent to Bob, one by one, as follows:
   
-2- For every $a_i$ and $b_i$: 
-* If $a_i = 0$ and $b_i = 0$ Alice sends a qubit with the state $|0\rangle$ to Bob.
-* If $a_i = 1$ and $b_i = 0$ Alice sends a qubit with the state $|1\rangle$ to Bob.
-* If $a_i = 0$ and $b_i = 1$ Alice sends a qubit with the state $|+\rangle$ to Bob.
-* If $a_i = 1$ and $b_i = 1$ Alice sends a qubit with the state $|-\rangle$ to Bob.
+2- For every **_a<sub>i</sub>_** and **_b<sub>i</sub>_**: 
+* If **_a<sub>i</sub> = 0_** and **_b<sub>i</sub> = 0_** Alice sends a qubit with the state **_|0>_** to Bob.
+* If **_a<sub>i</sub> = 1_** and **_b<sub>i</sub> = 0_** Alice sends a qubit with the state **_|1>_** to Bob.
+* If **_a<sub>i</sub> = 0_** and **_b<sub>i</sub> = 1_** Alice sends a qubit with the state **_|+>_** to Bob.
+* If **_a<sub>i</sub> = 1_** and **_b<sub>i</sub> = 1_** Alice sends a qubit with the state **_|->_** to Bob.
 
 3- For every qubit that Bob receives:
-* If $c_i = 0$ Bob measures the received qubit in the $0/1$ basis. 
-* If $c_i = 1$ Bob measures the received qubit in the $+/-$ basis.
-Bob stores the outcomes of the measurements in a string $r$.
+* If **_c<sub>i</sub> = 0_** Bob measures the received qubit in the **_0/1_** basis. 
+* If **_c<sub>i</sub> = 1_** Bob measures the received qubit in the **_+/-_** basis.
+Bob stores the outcomes of the measurements in a string **_r_**.
 
-4- Alice sends Bob the string $b$ and Bob sends Alice the string $c$.
+4- Alice sends Bob the string **_b_** and Bob sends Alice the string **_c_**.
 
-5- Alice and Bob compare the basis strings $b$ and $c$. Depending on where the string do not match, the corresponding bit in the string $r$ gets thrown out; i.e., for every $b_i \neq c_i$, Alice and Bob discard $r_i$. This produces a string $s$.
+5- Alice and Bob compare the basis strings **_b_** and **_c_**. Depending on where the string do not match, the corresponding bit in the string **_r_** gets thrown out; i.e., for every **_b<sub>i</sub> ≠ c<sub>i</sub>_**, Alice and Bob discard **_r<sub>i</sub>_**. This produces a string **_s_**.
 
-    If there was no eavesdropper, both Alice and Bob should have the same string $s$. If there was an eavesdropper, the strings will not match. Alice and Bob check if the strings match:
+    If there was no eavesdropper, both Alice and Bob should have the same string **_s_**. If there was an eavesdropper, the strings will not match. Alice and Bob check if the strings match:
 
 6- Alice chooses part of her string, and asks Bob to check if the corresponding part in his string matches. If they match, do nothing. If they don't match, abort the protocol.
 
-7- If the protocol was not aborted Alice and Bob discard the bits that were used for the check in step 6. The remaining string $k$ is the shared secret key.
+7- If the protocol was not aborted Alice and Bob discard the bits that were used for the check in step 6. The remaining string **_k_** is the shared secret key.
 
 ## Pseudo-Code (Alice's side)
 To be completed...


### PR DESCRIPTION
Readme wasn't readable and was written in latex. To make it more GitHub friendly, lets have markdown based syntax.